### PR TITLE
Initial pass_keys implementation.

### DIFF
--- a/include/ride/concurrency/detail/pass_keys.hpp
+++ b/include/ride/concurrency/detail/pass_keys.hpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2016 Nathan Currier
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+namespace ride {
+
+class ThreadPool;
+
+namespace detail {
+
+class WorkerThread;
+
+class CreateWorkerKey
+{
+    friend class ::ride::ThreadPool;
+
+    CreateWorkerKey() = default;
+    virtual ~CreateWorkerKey() = default;
+};
+
+class PoolWorkerKey
+{
+    friend class WorkerThread;
+
+    PoolWorkerKey() = default;
+    virtual ~PoolWorkerKey() = default;
+};
+
+} // end namespace detail
+
+} // end namespace ride
+

--- a/include/ride/concurrency/detail/worker_factory.hpp
+++ b/include/ride/concurrency/detail/worker_factory.hpp
@@ -18,11 +18,10 @@ class WorkerThread;
 
 class WorkerThreadFactory
 {
-    friend std::pair<std::thread::id, ThreadPool::PolymorphicWorker>
-        ThreadPool::createWorker(ThreadPool::PolymorphicWorkerFactory factory);
-  protected:
-    virtual std::unique_ptr<WorkerThread> create(ride::ThreadPool& owner) const = 0;
   public:
+    virtual std::unique_ptr<WorkerThread> create(const CreateWorkerKey&, ride::ThreadPool& owner) const = 0;
+
+    WorkerThreadFactory() = default;
     virtual ~WorkerThreadFactory() = default;
 };
 
@@ -30,12 +29,13 @@ template <class Worker_>
 class SimpleWorkerThreadFactory final
   : public WorkerThreadFactory
 {
-  protected:
-    std::unique_ptr<WorkerThread> create(ride::ThreadPool& owner) const override
-    {
-        return std::unique_ptr<WorkerThread>(new Worker_(owner));
-    }
   public:
+    std::unique_ptr<WorkerThread> create(const CreateWorkerKey& key, ride::ThreadPool& owner) const override
+    {
+        return std::unique_ptr<WorkerThread>(new Worker_(key, owner));
+    }
+
+    SimpleWorkerThreadFactory() = default;
     virtual ~SimpleWorkerThreadFactory() = default;
 };
 

--- a/include/ride/concurrency/worker.hpp
+++ b/include/ride/concurrency/worker.hpp
@@ -1,0 +1,20 @@
+// Copyright (c) 2016 Nathan Currier
+
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include <ride/concurrency/detail/worker.hpp>
+#include <ride/concurrency/detail/worker_factory.hpp>
+
+namespace ride {
+
+using Worker = detail::WorkerThread;
+
+template <class Worker_>
+using WorkerFactory = detail::SimpleWorkerThreadFactory<Worker_>;
+
+} // end namespace ride
+

--- a/src/pool.cpp
+++ b/src/pool.cpp
@@ -5,17 +5,13 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include <ride/concurrency/pool.hpp>
-#include <ride/concurrency/detail/worker.hpp>
-#include <ride/concurrency/detail/worker_factory.hpp>
 #include <ride/concurrency/detail/barrier.hpp>
-
-#include <algorithm>
 
 namespace ride {
 
 std::pair<std::thread::id, ThreadPool::PolymorphicWorker> ThreadPool::createWorker(PolymorphicWorkerFactory factory)
 {
-    PolymorphicWorker worker = factory->create(*this);
+    PolymorphicWorker worker = factory->create(creatorKey, *this);
     return std::make_pair(worker->getId(), std::move(worker));
 }
 
@@ -99,7 +95,7 @@ void ThreadPool::sync()
     lock.unlock();
 }
 
-void ThreadPool::handleOnShutdownWorker(detail::WorkerThread& worker)
+void ThreadPool::handleOnShutdownWorker(const detail::PoolWorkerKey&, detail::WorkerThread& worker)
 {
     this->onShutdownWorker(worker);
 

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -4,7 +4,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <ride/concurrency/detail/worker.hpp>
+#include <ride/concurrency/pool.hpp>
 
 namespace ride { namespace detail {
 


### PR DESCRIPTION
Pass keys are intended to restrict access of friendships
to a few select methods. I.e, a class/method must be able to
construct an empty class (through being a friend) in order to
call a pseudo-private method.
